### PR TITLE
Implement "hie" files for ghc-8.6.5

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -383,7 +383,7 @@ typeCheckRuleDefinition file = do
   res <- liftIO $ typecheckModule defer hsc (zipWith unpack mirs bytecodes) pm
 
   case res of
-    (diags, Just (hsc,tcm)) | supportsHieFiles -> do
+    (diags, Just (hsc,tcm)) -> do
       (_, contents) <- getFileContents file
       diagsHie <- liftIO $
         generateAndWriteHieFile hsc (TE.encodeUtf8 <$> contents) (tmrModule tcm)
@@ -494,9 +494,6 @@ getModIfaceRule :: Rules ()
 getModIfaceRule = define $ \GetModIface f -> do
     fileOfInterest <- use_ IsFileOfInterest f
     let useHiFile =
-          -- Interface files do not carry location information, so
-          -- never use interface files if .hie files are not available
-          supportsHieFiles &&
           -- Never load interface files for files of interest
           not fileOfInterest
     mbHiFile <- if useHiFile then use GetHiFile f else return Nothing

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -19,7 +19,6 @@ import Development.IDE.Spans.Type as SpanInfo
 import Development.IDE.Spans.Common (spanDocToMarkdown)
 
 -- GHC API imports
-import Avail
 import DynFlags
 import FastString
 import Name
@@ -139,11 +138,11 @@ locationsAtPoint getHieFile IdeOptions{..} pos =
                 -- so we instead read the .hie files to get useful source spans.
                 mod <- MaybeT $ return $ nameModule_maybe name
                 (hieFile, srcPath) <- MaybeT $ getHieFile mod
-                avail <- MaybeT $ pure $ listToMaybe (filterAvails (eqName name) $ hie_exports hieFile)
+                avail <- MaybeT $ pure $ listToMaybe (filter (eqName name . snd) $ hieExportNames hieFile)
                 -- The location will point to the source file used during compilation.
                 -- This file might no longer exists and even if it does the path will be relative
                 -- to the compilation directory which we don’t know.
-                let span = setFileName srcPath $ nameSrcSpan $ availName avail
+                let span = setFileName srcPath $ fst avail
                 pure span
         -- We ignore uniques and source spans and only compare the name and the module.
         eqName :: Name -> Name -> Bool


### PR DESCRIPTION
This means that the .hi files patch can also be used with 8.6.5